### PR TITLE
Update dependencies due to XRay Violations

### DIFF
--- a/gradle-examples/4/gradle-example-ci-server/api/build.gradle
+++ b/gradle-examples/4/gradle-example-ci-server/api/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compile module("commons-lang:commons-lang:2.4") {
         dependency("commons-io:commons-io:1.2")
     }
-    compile group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
+    compile group: 'org.apache.wicket', name: 'wicket', version: '[7.0.0-M3]'
     compile group: 'commons-httpclient', name: 'commons-httpclient', version: '3.0'
 
 }

--- a/gradle-examples/4/gradle-example-ci-server/services/webservice/build.gradle
+++ b/gradle-examples/4/gradle-example-ci-server/services/webservice/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'war'
 
 dependencies {
     compile project(':shared'), 'commons-collections:commons-collections:3.2@jar', 'commons-io:commons-io:1.2', 'commons-lang:commons-lang:2.4@jar'
-    compile group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
-    compile group: 'org.apache.struts', name: 'struts2-core', version: '2.3.14'
+    compile group: 'org.apache.wicket', name: 'wicket', version: '[7.0.0-M3]'
+    compile group: 'org.apache.struts', name: 'struts2-core', version: '[2.3.32]'
     compile group: 'junit', name: 'junit', version: '4.11'
     compile project(':api')
 }


### PR DESCRIPTION
**org.apache.wicket:wicket:1.3.7 => [7.0.0-M3]**
- CVE-2014-3526: Apache Wicket before 1.5.12, 6.x before 6.17.0, and 7.x before 7.0.0-M3 might allow remote attackers to obtain sensitive information via vectors involving identifiers for storing page markup for temporary user sessions.

**org.apache.struts:struts2-core:2.3.14 => [2.3.32]**
- CVE-2017-5638: The Jakarta Multipart parser in Apache Struts 2 2.3.x before 2.3.32 and 2.5.x before 2.5.10.1 mishandles file upload, which allows remote attackers to execute arbitrary commands via a #cmd= string in a crafted Content-Type HTTP header, as exploited in the wild in March 2017.